### PR TITLE
feat: track symbol, macro, and definition lookups

### DIFF
--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -759,6 +759,15 @@ public:
     /// Passthrough to sourceManager.notePeerDependency
     void notePeerDependency(BufferID dependent, BufferID peerDependency);
 
+    /// Resolves two pieces of syntax to files then notes their dependency
+    /// status
+    void noteDependency(const syntax::SyntaxNode* dependent, const syntax::SyntaxNode* dependency);
+
+    /// Resolves two pieces of syntax to files then notes their peer dependency
+    /// status
+    void notePeerDependency(const syntax::SyntaxNode* dependent,
+                            const syntax::SyntaxNode* dependency);
+
 private:
     friend class Lookup;
     friend class Scope;
@@ -816,6 +825,7 @@ private:
         const ConfigRule* configRule, const std::vector<Symbol*>& defList) const;
     Diagnostic* errorMissingDef(std::string_view name, const Scope& scope, SourceRange sourceRange,
                                 DiagCode code) const;
+    const syntax::SyntaxNode* getParentInFile(const syntax::SyntaxNode* node);
 
     // Stored options object.
     CompilationOptions options;

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -753,17 +753,11 @@ public:
 
     /// @}
 
-    /// Note a buffer's dependency on another buffer (include/consumed macro/consumed symbol)
+    /// Passthrough to sourceManager.noteDependency
     void noteDependency(BufferID dependent, BufferID dependency);
 
-    /// Returns the current dependency table as an immutable hashmap
-    const flat_hash_map<BufferID, std::set<BufferID>>& getDependencyTable() const;
-
-    /// Returns the dependencies of a buffer as an immutable set
-    const std::set<BufferID>& getDependencies(BufferID dependent);
-
-    /// Returns whether one buffer depends on another buffer
-    bool bufferDepends(BufferID dependent, BufferID dependency) const;
+    /// Passthrough to sourceManager.notePeerDependency
+    void notePeerDependency(BufferID dependent, BufferID peerDependency);
 
 private:
     friend class Lookup;

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 
 #include "slang/ast/ASTDiagMap.h"
 #include "slang/ast/OpaqueInstancePath.h"
@@ -751,6 +752,18 @@ public:
     const syntax::ImplicitTypeSyntax& createEmptyTypeSyntax(SourceLocation loc);
 
     /// @}
+
+    /// Note a buffer's dependency on another buffer (include/consumed macro/consumed symbol)
+    void noteDependency(BufferID dependent, BufferID dependency);
+
+    /// Returns the current dependency table as an immutable hashmap
+    const flat_hash_map<BufferID, std::set<BufferID>>& getDependencyTable() const;
+
+    /// Returns the dependencies of a buffer as an immutable set
+    const std::set<BufferID>& getDependencies(BufferID dependent);
+
+    /// Returns whether one buffer depends on another buffer
+    bool bufferDepends(BufferID dependent, BufferID dependency) const;
 
 private:
     friend class Lookup;

--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -229,6 +229,18 @@ public:
     /// source manager.
     std::vector<BufferID> getAllBuffers() const;
 
+    /// Note a buffer's dependency on another buffer (include/consumed macro/consumed symbol)
+    void noteDependency(BufferID dependent, BufferID dependency);
+
+    /// Returns the current dependency table as an immutable hashmap
+    const flat_hash_map<BufferID, std::set<BufferID>>& getDependencyTable() const;
+
+    /// Returns the dependencies of a buffer as an immutable set
+    const std::set<BufferID>& getDependencies(BufferID dependent);
+
+    /// Returns whether one buffer depends on another buffer
+    bool bufferDepends(BufferID dependent, BufferID dependency) const;
+
 private:
     // Stores information specified in a `line directive, which alters the
     // line number and file name that we report in diagnostics.
@@ -320,6 +332,9 @@ private:
 
     // map from buffer to diagnostic directive lists
     flat_hash_map<BufferID, std::vector<DiagnosticDirectiveInfo>> diagDirectives;
+
+    // table representing dependencies between buffers
+    flat_hash_map<BufferID, std::set<BufferID>> dependencyTable;
 
     std::atomic<uint32_t> unnamedBufferCount = 0;
     bool disableProximatePaths = false;

--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -232,14 +232,17 @@ public:
     /// Note a buffer's dependency on another buffer (include/consumed macro/consumed symbol)
     void noteDependency(BufferID dependent, BufferID dependency);
 
+    /// Note a buffer's peer dependency on another buffer (module/extern subroutine)
+    void notePeerDependency(BufferID dependent, BufferID peerDependency);
+
     /// Returns the current dependency table as an immutable hashmap
     const flat_hash_map<BufferID, std::set<BufferID>>& getDependencyTable() const;
 
     /// Returns the dependencies of a buffer as an immutable set
     const std::set<BufferID>& getDependencies(BufferID dependent);
 
-    /// Returns whether one buffer depends on another buffer
-    bool bufferDepends(BufferID dependent, BufferID dependency) const;
+    /// Returns the peer dependencies of a buffer as an immutable set
+    const std::set<BufferID>& getPeerDependencies(BufferID dependent);
 
 private:
     // Stores information specified in a `line directive, which alters the
@@ -333,8 +336,13 @@ private:
     // map from buffer to diagnostic directive lists
     flat_hash_map<BufferID, std::vector<DiagnosticDirectiveInfo>> diagDirectives;
 
-    // table representing dependencies between buffers
+    // table representing direct dependencies between buffers: buffer A must be
+    // loaded at least before buffer B
     flat_hash_map<BufferID, std::set<BufferID>> dependencyTable;
+
+    // table representing indirect dependencies between buffers: the order
+    // doesn't matter, but the two buffers should eventually be loaded together
+    flat_hash_map<BufferID, std::set<BufferID>> peerDependencyTable;
 
     std::atomic<uint32_t> unnamedBufferCount = 0;
     bool disableProximatePaths = false;

--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -2550,21 +2550,13 @@ void Compilation::noteDependency(BufferID dependent, BufferID dependency) {
     sourceManager->noteDependency(dependent, dependency);
 }
 
-const flat_hash_map<BufferID, std::set<BufferID>>& Compilation::getDependencyTable() const {
-    return sourceManager->getDependencyTable();
-}
-
-const std::set<BufferID>& Compilation::getDependencies(BufferID dependent) {
-    return sourceManager->getDependencies(dependent);
-}
-
-bool Compilation::bufferDepends(BufferID dependent, BufferID dependency) const {
-    return sourceManager->bufferDepends(dependent, dependency);
+void Compilation::notePeerDependency(BufferID dependent, BufferID peerDependency) {
+    sourceManager->notePeerDependency(dependent, peerDependency);
 }
 
 template<typename TDefList>
-auto findDefByLib(TDefList& defList, const SourceLibrary& target)
-    -> std::remove_reference_t<decltype(defList[0])> {
+auto findDefByLib(TDefList& defList,
+                  const SourceLibrary& target) -> std::remove_reference_t<decltype(defList[0])> {
     for (auto def : defList) {
         if (def->getSourceLibrary() == &target)
             return def;

--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -2546,6 +2546,22 @@ void Compilation::resolveDefParamsAndBinds() {
     copyStateInto(*this, true);
 }
 
+void Compilation::noteDependency(BufferID dependent, BufferID dependency) {
+    sourceManager->noteDependency(dependent, dependency);
+}
+
+const flat_hash_map<BufferID, std::set<BufferID>>& Compilation::getDependencyTable() const {
+    return sourceManager->getDependencyTable();
+}
+
+const std::set<BufferID>& Compilation::getDependencies(BufferID dependent) {
+    return sourceManager->getDependencies(dependent);
+}
+
+bool Compilation::bufferDepends(BufferID dependent, BufferID dependency) const {
+    return sourceManager->bufferDepends(dependent, dependency);
+}
+
 template<typename TDefList>
 auto findDefByLib(TDefList& defList, const SourceLibrary& target)
     -> std::remove_reference_t<decltype(defList[0])> {

--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -2554,6 +2554,35 @@ void Compilation::notePeerDependency(BufferID dependent, BufferID peerDependency
     sourceManager->notePeerDependency(dependent, peerDependency);
 }
 
+const SyntaxNode* Compilation::getParentInFile(const SyntaxNode* node) {
+    while (node != nullptr && !sourceManager->isFileLoc(node->getFirstToken().location())) {
+        node = node->parent;
+    }
+    return node;
+};
+
+void Compilation::noteDependency(const syntax::SyntaxNode* dependent,
+                                 const syntax::SyntaxNode* dependency) {
+    // For some reason, in this context specifically, getFullyOriginalLoc
+    // doesn't seem to be cutting it.
+    dependent = getParentInFile(dependent);
+    dependency = getParentInFile(dependency);
+    if (dependent != nullptr && dependency != nullptr)
+        noteDependency(dependent->getFirstToken().location().buffer(),
+                       dependency->getFirstToken().location().buffer());
+}
+
+void Compilation::notePeerDependency(const syntax::SyntaxNode* dependent,
+                                     const syntax::SyntaxNode* dependency) {
+    // For some reason, in this context specifically, getFullyOriginalLoc
+    // doesn't seem to be cutting it.
+    dependent = getParentInFile(dependent);
+    dependency = getParentInFile(dependency);
+    if (dependent != nullptr && dependency != nullptr)
+        notePeerDependency(dependent->getFirstToken().location().buffer(),
+                           dependency->getFirstToken().location().buffer());
+}
+
 template<typename TDefList>
 auto findDefByLib(TDefList& defList,
                   const SourceLibrary& target) -> std::remove_reference_t<decltype(defList[0])> {

--- a/source/ast/Lookup.cpp
+++ b/source/ast/Lookup.cpp
@@ -689,9 +689,31 @@ bool checkVisibility(const Symbol& symbol, const Scope& scope,
     return false;
 }
 
-struct Defer {
-    std::function<void()> fn;
-    ~Defer() { fn(); }
+/// @brief This struct, upon deconstruction, checks if the LookupResult is
+/// valid, and if so, marks a dependency between two buffers: the one containing
+/// syntax that caused a lookup, and the one that declared the symbol that
+/// was successfully looked up.
+struct DependencySpy {
+    Compilation* compilation;
+    const SyntaxNode* originatingSyntax;
+    LookupResult* result;
+    ~DependencySpy() {
+        if (originatingSyntax == nullptr) {
+            // Intermediate lookup
+            return;
+        }
+        if (result->found == nullptr) {
+            // Nothing found, nothing to register
+            return;
+        }
+        auto sm = compilation->getSourceManager();
+        auto referencing = sm->getFullyOriginalLoc(originatingSyntax->getFirstToken().location());
+        auto referenced = sm->getFullyOriginalLoc(
+            result->found->getSyntax()->getFirstToken().location());
+        if (sm->isFileLoc(referencing) && sm->isFileLoc(referenced)) {
+            compilation->noteDependency(referencing.buffer(), referenced.buffer());
+        }
+    }
 };
 
 bool resolveColonNames(SmallVectorBase<NamePlusLoc>& nameParts, int colonParts,
@@ -1719,21 +1741,7 @@ void Lookup::unqualifiedImpl(const Scope& scope, std::string_view name, LookupLo
                              std::optional<SourceRange> sourceRange, bitmask<LookupFlags> flags,
                              SymbolIndex outOfBlockIndex, LookupResult& result,
                              const Scope& originalScope, const SyntaxNode* originalSyntax) {
-    // Deferred: if a valid LookupResult is returned, register the dependency
-    Defer _{[&] {
-        if (result.found == nullptr) {
-            // Not found, nothing to register.
-            return;
-        }
-        if (originalSyntax == nullptr)
-            // Intermediate lookup, leave registration to qualified
-            return;
-
-        auto referencingBuffer = originalSyntax->getFirstToken().location().buffer();
-        auto referencedBuffer = result.found->getSyntax()->getFirstToken().location().buffer();
-        auto sm = scope.getCompilation().getSourceManager();
-        scope.getCompilation().noteDependency(referencingBuffer, referencedBuffer);
-    }};
+    DependencySpy spy{&scope.getCompilation(), originalSyntax, &result};
     auto reportRecursiveError = [&](const Symbol& symbol) {
         if (sourceRange) {
             auto& diag = result.addDiag(scope, diag::RecursiveDefinition, *sourceRange);
@@ -2047,17 +2055,7 @@ void Lookup::unqualifiedImpl(const Scope& scope, std::string_view name, LookupLo
 
 void Lookup::qualified(const ScopedNameSyntax& syntax, const ASTContext& context,
                        bitmask<LookupFlags> flags, LookupResult& result) {
-
-    // Deferred: if a valid LookupResult is returned, register the dependency
-    Defer _{[&](...) {
-        if (result.found == nullptr) {
-            // Not found, nothing to register
-            return;
-        }
-        auto referencingBuffer = syntax.getFirstToken().location().buffer();
-        auto referencedBuffer = result.found->getSyntax()->getFirstToken().location().buffer();
-        context.getCompilation().noteDependency(referencingBuffer, referencedBuffer);
-    }};
+    DependencySpy spy{&context.getCompilation(), &syntax, &result};
     // Split the name into easier to manage chunks. The parser will always produce a
     // left-recursive name tree, so that's all we'll bother to handle.
     int colonParts = 0;

--- a/source/ast/Lookup.cpp
+++ b/source/ast/Lookup.cpp
@@ -689,7 +689,7 @@ bool checkVisibility(const Symbol& symbol, const Scope& scope,
     return false;
 }
 
-/// @brief This struct, upon deconstruction, checks if the LookupResult is
+/// @brief This struct, upon destruction, checks if the LookupResult is
 /// valid, and if so, marks a dependency between two buffers: the one containing
 /// syntax that caused a lookup, and the one that declared the symbol that
 /// was successfully looked up.

--- a/source/ast/Lookup.cpp
+++ b/source/ast/Lookup.cpp
@@ -689,6 +689,11 @@ bool checkVisibility(const Symbol& symbol, const Scope& scope,
     return false;
 }
 
+struct Defer {
+    std::function<void()> fn;
+    ~Defer() { fn(); }
+};
+
 bool resolveColonNames(SmallVectorBase<NamePlusLoc>& nameParts, int colonParts,
                        NameComponents& name, bitmask<LookupFlags> flags, LookupResult& result,
                        const ASTContext& context) {
@@ -1714,6 +1719,21 @@ void Lookup::unqualifiedImpl(const Scope& scope, std::string_view name, LookupLo
                              std::optional<SourceRange> sourceRange, bitmask<LookupFlags> flags,
                              SymbolIndex outOfBlockIndex, LookupResult& result,
                              const Scope& originalScope, const SyntaxNode* originalSyntax) {
+    // Deferred: if a valid LookupResult is returned, register the dependency
+    Defer _{[&] {
+        if (result.found == nullptr) {
+            // Not found, nothing to register.
+            return;
+        }
+        if (originalSyntax == nullptr)
+            // Intermediate lookup, leave registration to qualified
+            return;
+
+        auto referencingBuffer = originalSyntax->getFirstToken().location().buffer();
+        auto referencedBuffer = result.found->getSyntax()->getFirstToken().location().buffer();
+        auto sm = scope.getCompilation().getSourceManager();
+        scope.getCompilation().noteDependency(referencingBuffer, referencedBuffer);
+    }};
     auto reportRecursiveError = [&](const Symbol& symbol) {
         if (sourceRange) {
             auto& diag = result.addDiag(scope, diag::RecursiveDefinition, *sourceRange);
@@ -2027,6 +2047,17 @@ void Lookup::unqualifiedImpl(const Scope& scope, std::string_view name, LookupLo
 
 void Lookup::qualified(const ScopedNameSyntax& syntax, const ASTContext& context,
                        bitmask<LookupFlags> flags, LookupResult& result) {
+
+    // Deferred: if a valid LookupResult is returned, register the dependency
+    Defer _{[&](...) {
+        if (result.found == nullptr) {
+            // Not found, nothing to register
+            return;
+        }
+        auto referencingBuffer = syntax.getFirstToken().location().buffer();
+        auto referencedBuffer = result.found->getSyntax()->getFirstToken().location().buffer();
+        context.getCompilation().noteDependency(referencingBuffer, referencedBuffer);
+    }};
     // Split the name into easier to manage chunks. The parser will always produce a
     // left-recursive name tree, so that's all we'll bother to handle.
     int colonParts = 0;

--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -663,7 +663,7 @@ void InstanceSymbol::fromSyntax(Compilation& comp, const HierarchyInstantiationS
         const SyntaxNode* instanceSyntax = firstFileParent(&syntax);
         const SyntaxNode* defSyntax = firstFileParent(def->getSyntax());
         if (instanceSyntax != nullptr && defSyntax != nullptr)
-            context.getCompilation().noteDependency(
+            context.getCompilation().notePeerDependency(
                 instanceSyntax->getFirstToken().location().buffer(),
                 defSyntax->getFirstToken().location().buffer());
         definition.noteInstantiated();

--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -648,6 +648,8 @@ void InstanceSymbol::fromSyntax(Compilation& comp, const HierarchyInstantiationS
         }
 
         auto& definition = def->as<DefinitionSymbol>();
+        context.getCompilation().noteDependency(syntax.getFirstToken().location().buffer(),
+                                                def->location.buffer());
         definition.noteInstantiated();
 
         if (inChecker) {

--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -649,23 +649,7 @@ void InstanceSymbol::fromSyntax(Compilation& comp, const HierarchyInstantiationS
         }
 
         auto& definition = def->as<DefinitionSymbol>();
-        auto sourceManager = comp.getSourceManager();
-        std::function<const SyntaxNode*(const SyntaxNode*)> firstFileParent =
-            [&](const SyntaxNode* node) {
-                if (node == nullptr) {
-                    return node;
-                }
-                if (sourceManager->isFileLoc(node->getFirstToken().location())) {
-                    return node;
-                }
-                return firstFileParent(node->parent);
-            };
-        const SyntaxNode* instanceSyntax = firstFileParent(&syntax);
-        const SyntaxNode* defSyntax = firstFileParent(def->getSyntax());
-        if (instanceSyntax != nullptr && defSyntax != nullptr)
-            context.getCompilation().notePeerDependency(
-                instanceSyntax->getFirstToken().location().buffer(),
-                defSyntax->getFirstToken().location().buffer());
+        context.getCompilation().notePeerDependency(&syntax, def->getSyntax());
         definition.noteInstantiated();
 
         if (inChecker) {

--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -29,6 +29,7 @@
 #include "slang/diagnostics/ExpressionsDiags.h"
 #include "slang/diagnostics/ParserDiags.h"
 #include "slang/syntax/AllSyntax.h"
+#include "slang/text/SourceManager.h"
 #include "slang/util/TimeTrace.h"
 #include "slang/util/TypeTraits.h"
 
@@ -648,8 +649,23 @@ void InstanceSymbol::fromSyntax(Compilation& comp, const HierarchyInstantiationS
         }
 
         auto& definition = def->as<DefinitionSymbol>();
-        context.getCompilation().noteDependency(syntax.getFirstToken().location().buffer(),
-                                                def->location.buffer());
+        auto sourceManager = comp.getSourceManager();
+        std::function<const SyntaxNode*(const SyntaxNode*)> firstFileParent =
+            [&](const SyntaxNode* node) {
+                if (node == nullptr) {
+                    return node;
+                }
+                if (sourceManager->isFileLoc(node->getFirstToken().location())) {
+                    return node;
+                }
+                return firstFileParent(node->parent);
+            };
+        const SyntaxNode* instanceSyntax = firstFileParent(&syntax);
+        const SyntaxNode* defSyntax = firstFileParent(def->getSyntax());
+        if (instanceSyntax != nullptr && defSyntax != nullptr)
+            context.getCompilation().noteDependency(
+                instanceSyntax->getFirstToken().location().buffer(),
+                defSyntax->getFirstToken().location().buffer());
         definition.noteInstantiated();
 
         if (inChecker) {

--- a/source/ast/symbols/SubroutineSymbols.cpp
+++ b/source/ast/symbols/SubroutineSymbols.cpp
@@ -1176,20 +1176,7 @@ const SubroutineSymbol* MethodPrototypeSymbol::getSubroutine() const {
         return nullptr;
     }
 
-    std::function<const SyntaxNode*(const SyntaxNode*)> firstFileParent =
-        [&](const SyntaxNode* node) {
-            if (node == nullptr) {
-                return node;
-            }
-            if (comp.getSourceManager()->isFileLoc(node->getFirstToken().location())) {
-                return node;
-            }
-            return firstFileParent(node->parent);
-        };
-    const SyntaxNode* declSyntaxResolved = firstFileParent(parentSym.getSyntax());
-    const SyntaxNode* defSyntaxResolved = firstFileParent(syntax);
-    comp.notePeerDependency(declSyntaxResolved->getFirstToken().location().buffer(),
-                            defSyntaxResolved->getFirstToken().location().buffer());
+    comp.notePeerDependency(parentSym.getSyntax(), syntax);
 
     // The method definition must be located after the class definition.
     if (index <= parentSym.getIndex()) {

--- a/source/ast/symbols/SubroutineSymbols.cpp
+++ b/source/ast/symbols/SubroutineSymbols.cpp
@@ -22,6 +22,7 @@
 #include "slang/diagnostics/LookupDiags.h"
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxFacts.h"
+#include "slang/text/SourceManager.h"
 
 namespace slang::ast {
 
@@ -1174,6 +1175,21 @@ const SubroutineSymbol* MethodPrototypeSymbol::getSubroutine() const {
         outerScope.addDiag(diag::NoMemberImplFound, location) << name;
         return nullptr;
     }
+
+    std::function<const SyntaxNode*(const SyntaxNode*)> firstFileParent =
+        [&](const SyntaxNode* node) {
+            if (node == nullptr) {
+                return node;
+            }
+            if (comp.getSourceManager()->isFileLoc(node->getFirstToken().location())) {
+                return node;
+            }
+            return firstFileParent(node->parent);
+        };
+    const SyntaxNode* declSyntaxResolved = firstFileParent(parentSym.getSyntax());
+    const SyntaxNode* defSyntaxResolved = firstFileParent(syntax);
+    comp.notePeerDependency(declSyntaxResolved->getFirstToken().location().buffer(),
+                            defSyntaxResolved->getFirstToken().location().buffer());
 
     // The method definition must be located after the class definition.
     if (index <= parentSym.getIndex()) {

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -560,6 +560,8 @@ Trivia Preprocessor::handleIncludeDirective(Token directive) {
             includeDepth++;
             pushSource(*buffer);
 
+            sourceManager.noteDependency(syntax->getFirstToken().location().buffer(), buffer->id);
+
             includeDirectives.push_back(IncludeMetadata{
                 .syntax = syntax,
                 .path = path,

--- a/source/parsing/Preprocessor_macros.cpp
+++ b/source/parsing/Preprocessor_macros.cpp
@@ -129,6 +129,9 @@ std::pair<MacroActualArgumentListSyntax*, Trivia> Preprocessor::handleTopLevelMa
     if (!expandedTokens.empty())
         currentMacroToken = expandedTokens.begin();
 
+    sourceManager.noteDependency(directive.location().buffer(),
+                                 macro.syntax->getFirstToken().location().buffer());
+
     return {actualArgs, Trivia()};
 }
 

--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -727,4 +727,23 @@ const SourceManager::LineDirectiveInfo* SourceManager::FileInfo::getPreviousLine
     }
 }
 
+void SourceManager::noteDependency(BufferID dependent, BufferID dependency) {
+    if (dependent != dependency) {
+        dependencyTable[dependent].insert(dependency);
+    }
+}
+
+const flat_hash_map<BufferID, std::set<BufferID>>& SourceManager::getDependencyTable() const {
+    return dependencyTable;
+}
+
+const std::set<BufferID>& SourceManager::getDependencies(BufferID dependent) {
+    return dependencyTable[dependent];
+}
+
+bool SourceManager::bufferDepends(BufferID dependent, BufferID dependency) const {
+    auto found = dependencyTable.find(dependent);
+    return found != dependencyTable.end() ? found->second.count(dependency) : false;
+}
+
 } // namespace slang

--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -733,6 +733,12 @@ void SourceManager::noteDependency(BufferID dependent, BufferID dependency) {
     }
 }
 
+void SourceManager::notePeerDependency(BufferID dependent, BufferID peerDependency) {
+    if (dependent != peerDependency) {
+        peerDependencyTable[dependent].insert(peerDependency);
+    }
+}
+
 const flat_hash_map<BufferID, std::set<BufferID>>& SourceManager::getDependencyTable() const {
     return dependencyTable;
 }
@@ -741,9 +747,8 @@ const std::set<BufferID>& SourceManager::getDependencies(BufferID dependent) {
     return dependencyTable[dependent];
 }
 
-bool SourceManager::bufferDepends(BufferID dependent, BufferID dependency) const {
-    auto found = dependencyTable.find(dependent);
-    return found != dependencyTable.end() ? found->second.count(dependency) : false;
+const std::set<BufferID>& SourceManager::getPeerDependencies(BufferID dependent) {
+    return peerDependencyTable[dependent];
 }
 
 } // namespace slang


### PR DESCRIPTION
Adds a table to SourceManager that keeps track of inter-file dependencies. This table is populated via the `noteDependency` method (that is re-exported in `Compilation` to avoid breaking the `const` constraint on its `getSourceManager`.)

Spies have been installed in:

* `source/parsing/Preprocessor.cpp`
* `source/parsing/Preprocessor_macro.cpp`
* `source/ast/Lookup.cc`
* `source/ast/symbols/InstanceSymbols.cpp`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds inter-file dependency tracking to `SourceManager` and integrates it into parsing and AST components.
> 
>   - **Behavior**:
>     - Adds dependency tracking to `SourceManager` with `noteDependency` and `notePeerDependency` methods.
>     - Updates `Compilation` to expose `noteDependency` and `notePeerDependency` methods for syntax nodes.
>     - Tracks dependencies in `Preprocessor.cpp` and `Preprocessor_macros.cpp` during include and macro handling.
>     - Tracks peer dependencies in `InstanceSymbols.cpp` and `SubroutineSymbols.cpp` during instance and subroutine processing.
>   - **Data Structures**:
>     - Adds `dependencyTable` and `peerDependencyTable` to `SourceManager`.
>     - Provides methods to retrieve dependencies and peer dependencies.
>   - **Misc**:
>     - Introduces `DependencySpy` in `Lookup.cpp` to track symbol lookup dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fslang&utm_source=github&utm_medium=referral)<sup> for 8e413ef0f1bff25b1249e871c1190c3d48b84f12. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->