### PR TITLE
dependency spy: fix memory issues

### DIFF
--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -235,14 +235,11 @@ public:
     /// Note a buffer's peer dependency on another buffer (module/extern subroutine)
     void notePeerDependency(BufferID dependent, BufferID peerDependency);
 
-    /// Returns the current dependency table as an immutable hashmap
-    const flat_hash_map<BufferID, std::set<BufferID>>& getDependencyTable() const;
-
     /// Returns the dependencies of a buffer as an immutable set
-    const std::set<BufferID>& getDependencies(BufferID dependent);
+    const std::set<BufferID> getDependencies(BufferID dependent) const;
 
     /// Returns the peer dependencies of a buffer as an immutable set
-    const std::set<BufferID>& getPeerDependencies(BufferID dependent);
+    const std::set<BufferID> getPeerDependencies(BufferID dependent) const;
 
 private:
     // Stores information specified in a `line directive, which alters the

--- a/source/ast/Lookup.cpp
+++ b/source/ast/Lookup.cpp
@@ -706,13 +706,7 @@ struct DependencySpy {
             // Nothing found, nothing to register
             return;
         }
-        auto sm = compilation->getSourceManager();
-        auto referencing = sm->getFullyOriginalLoc(originatingSyntax->getFirstToken().location());
-        auto referenced = sm->getFullyOriginalLoc(
-            result->found->getSyntax()->getFirstToken().location());
-        if (sm->isFileLoc(referencing) && sm->isFileLoc(referenced)) {
-            compilation->noteDependency(referencing.buffer(), referenced.buffer());
-        }
+        compilation->noteDependency(originatingSyntax, result->found->getSyntax());
     }
 };
 

--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -752,26 +752,37 @@ const SourceManager::LineDirectiveInfo* SourceManager::FileInfo::getPreviousLine
 
 void SourceManager::noteDependency(BufferID dependent, BufferID dependency) {
     if (dependent != dependency) {
+        std::unique_lock<std::shared_mutex> lock(mutex);
         dependencyTable[dependent].insert(dependency);
     }
 }
 
 void SourceManager::notePeerDependency(BufferID dependent, BufferID peerDependency) {
     if (dependent != peerDependency) {
+        std::unique_lock<std::shared_mutex> lock(mutex);
         peerDependencyTable[dependent].insert(peerDependency);
     }
 }
 
-const flat_hash_map<BufferID, std::set<BufferID>>& SourceManager::getDependencyTable() const {
-    return dependencyTable;
+const std::set<BufferID> SourceManager::getDependencies(BufferID dependent) const {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    auto it = dependencyTable.find(dependent);
+    if (it != dependencyTable.end()) {
+        return it->second;
+    } else {
+        return {};
+    }
+
 }
 
-const std::set<BufferID>& SourceManager::getDependencies(BufferID dependent) {
-    return dependencyTable[dependent];
-}
-
-const std::set<BufferID>& SourceManager::getPeerDependencies(BufferID dependent) {
-    return peerDependencyTable[dependent];
+const std::set<BufferID> SourceManager::getPeerDependencies(BufferID dependent) const {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    auto it = peerDependencyTable.find(dependent);
+    if (it != peerDependencyTable.end()) {
+        return it->second;
+    } else {
+        return {};
+    }
 }
 
 } // namespace slang


### PR DESCRIPTION
- `SourceManager::{noteDependency,notePeerDependency}`: fix missing mutex lock
- `SourceManager::{getDependencies,getPeerDependencies}`: fix invisible mutation that may cause stale references, also just return by value
- `DependencySpy`: Fix issue where unexpanded macro may form dependency on target declared in expanded macro
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix memory issues in `SourceManager` and `DependencySpy` by adding mutex locks, changing return types, and correcting macro handling.
> 
>   - **Concurrency Fixes**:
>     - Add missing mutex locks in `SourceManager::noteDependency` and `SourceManager::notePeerDependency` to prevent data races.
>   - **Return Type Changes**:
>     - Change return type of `SourceManager::getDependencies` and `SourceManager::getPeerDependencies` to return by value to avoid stale references.
>   - **Bug Fixes**:
>     - Fix `DependencySpy` to correctly handle dependencies involving unexpanded macros in `Lookup.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fslang&utm_source=github&utm_medium=referral)<sup> for ab57b3aa44bdfe7791e1d8c2eca25a59b75603db. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->