### PR TITLE
feat: add new methods to expose search information

### DIFF
--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -426,6 +426,9 @@ public:
     /// Prints a note to stderr with appropriate terminal colors.
     void printNote(const std::string& message);
 
+    /// Get processed command paths
+    const flat_hash_set<std::filesystem::path> &getProcessedCommandFiles() const { return processedCommandFiles; }
+
 private:
     bool parseUnitListing(std::string_view text);
     void addLibraryFiles(std::string_view pattern);
@@ -435,6 +438,7 @@ private:
 
     bool anyFailedLoads = false;
     flat_hash_set<std::filesystem::path> activeCommandFiles;
+    flat_hash_set<std::filesystem::path> processedCommandFiles;
     std::vector<std::tuple<std::string_view, std::string_view, std::string_view>>
         translateOffFormats;
     std::unique_ptr<JsonWriter> jsonWriter;

--- a/include/slang/driver/SourceLoader.h
+++ b/include/slang/driver/SourceLoader.h
@@ -152,6 +152,18 @@ public:
     /// it does not exist. Returns nullptr if @a name is empty.
     SourceLibrary* getOrAddLibrary(std::string_view name);
 
+    /// Get Library Files
+    std::vector<std::pair<const SourceLibrary *, const std::filesystem::path>> getLibraryFiles() const;
+
+    /// Get Library Map Files
+    std::span<const std::filesystem::path> getLibraryMapFiles() const { return libraryMapFiles; }
+
+    /// Get Search Directories
+    std::span<const std::filesystem::path> getSearchDirectories() const { return searchDirectories; }
+
+    /// Get Search Extensions
+    std::span<const std::filesystem::path> getSearchExtensions() const { return searchExtensions; }
+
 private:
     // One entry per unit of files + options to compile them.
     // Only used for addSeparateUnit.
@@ -236,6 +248,7 @@ private:
     std::vector<std::filesystem::path> searchExtensions;
     flat_hash_set<std::string_view> uniqueExtensions;
     std::vector<std::string> errors;
+    std::vector<std::filesystem::path> libraryMapFiles;
     SyntaxTreeList libraryMapTrees;
 
     static constexpr int MinFilesForThreading = 4;

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -507,6 +507,7 @@ bool Driver::processCommandFiles(std::string_view pattern, bool makeRelative, bo
             fs::current_path(currPath, ec);
 
         activeCommandFiles.erase(path);
+        processedCommandFiles.insert(path);
 
         if (!result) {
             anyFailedLoads = true;

--- a/source/driver/SourceLoader.cpp
+++ b/source/driver/SourceLoader.cpp
@@ -134,6 +134,8 @@ void SourceLoader::addLibraryMapsInternal(std::string_view pattern, const fs::pa
             continue;
         }
 
+        libraryMapFiles.push_back(path);
+
         auto tree = SyntaxTree::fromLibraryMapBuffer(*buffer, sourceManager, optionBag);
         libraryMapTrees.push_back(tree);
 
@@ -542,6 +544,18 @@ SourceLoader::LoadResult SourceLoader::loadAndParse(const FileEntry& entry, cons
 
 void SourceLoader::addError(const std::filesystem::path& path, std::error_code ec) {
     errors.emplace_back(fmt::format("'{}': {}", getU8Str(path), ec.message()));
+}
+
+std::vector<std::pair<const SourceLibrary*, const std::filesystem::path>> SourceLoader::
+    getLibraryFiles() const {
+    std::vector<std::pair<const SourceLibrary*, const std::filesystem::path>> result;
+    for (auto& entry : fileEntries) {
+        if (!entry.isLibraryFile) {
+            continue;
+        }
+        result.push_back({entry.library, entry.path});
+    }
+    return result;
 }
 
 } // namespace slang::driver


### PR DESCRIPTION
- add `SourceLoader::getLibraryFiles`, returns files that are part of a specific source library (provided using -v or implicitly using --libmap)
- add `SourceLoader::getSearchDirectories` to return library search paths which will be searched for missing modules (provided using -y)
- add `SourceLoader::getSearchExtensions` which returns user-defined library search extensions (provided using -Y)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add methods to `SourceLoader` and `Driver` to expose library files, search directories, extensions, and processed command paths.
> 
>   - **New Methods in `SourceLoader`**:
>     - `getLibraryFiles()`: Returns files part of a specific source library.
>     - `getSearchDirectories()`: Returns library search paths for missing modules.
>     - `getSearchExtensions()`: Returns user-defined library search extensions.
>   - **New Method in `Driver`**:
>     - `getProcessedCommandFiles()`: Returns processed command paths.
>   - **Misc**:
>     - Add `processedCommandFiles` to track processed command files in `Driver`.
>     - Add `libraryMapFiles` to track library map files in `SourceLoader`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fslang&utm_source=github&utm_medium=referral)<sup> for 0a4b65d95db11eb8c4c69e23f0aebc3974c4a724. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->